### PR TITLE
Remove uneccesary require('bunyan') call in rotatingfilestream.

### DIFF
--- a/lib/rotatingfilestream.js
+++ b/lib/rotatingfilestream.js
@@ -15,8 +15,6 @@ var LimitedQueue = require('./limitedqueue');
 var FileRotator = require('./filerotator');
 var semver = require('semver');
 
-var bunyan = require('bunyan');
-
 var _DEBUG = false;
 
 // There is an annoying bug where setImmediate sometimes doesn't fire.


### PR DESCRIPTION
This bunyan var is not used, and can cause problems if consuming library is using a scoped / renamed bunyan library.
