### PR TITLE
Fix / Declare bunyan Peer Dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
       },
       "engines": {
         "node": ">=14.17.0"
+      },
+      "peerDependencies": {
+        "bunyan": "^1.8.15"
       }
     },
     "node_modules/async": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "uuid": "^8.3.2",
     "why-is-node-running": "^2.2.0"
   },
+  "peerDependencies": {
+    "bunyan": "^1.8.15"
+  },
   "dependencies": {
     "async": "^3.2.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Given that we depend on `bunyan` at runtime as a peer dependency it makes sense to declare this to package consumers. It needs to remain in as a dev dependency as well otherwise it won't be installed for devs, but this will declare the runtime dependency to package consumers without installing it for them.

**Note:** Contribution guidelines say I need to `make check`, but that currently does this for me:

```console
❯ make check
make: *** No rule to make target `check'.  Stop.
```

But I believe I'm following the coding style. Definitely let me know if I need to do anything else here.