### PR TITLE
Removing unused imports.

### DIFF
--- a/lib/rotatingfilestream.js
+++ b/lib/rotatingfilestream.js
@@ -5,9 +5,6 @@
 'use strict';
 
 var EventEmitter = require('events').EventEmitter;
-var fs = require('fs');
-var iopath = require('path');
-var async = require('async');
 var _ = require('lodash');
 
 var optionParser = require('./optionParser');

--- a/lib/thresholdtrigger.js
+++ b/lib/thresholdtrigger.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var fs = require('fs');
 var EventEmitter = require('events').EventEmitter;
 var _ = require('lodash');
 var optionParser = require('./optionParser');

--- a/test/performance.js
+++ b/test/performance.js
@@ -5,7 +5,6 @@ var assert = require('assert');
 var fse = require('fs-extra');
 var RotatingFileStream = require('../index');
 var async = require('async');
-var InitialPeriodRotateTrigger = require('../lib/initialperiodtrigger');
 var whyRunning;
 
 try {

--- a/test/stress.js
+++ b/test/stress.js
@@ -7,21 +7,8 @@ var fs = require('fs');
 var async = require('async');
 var path = require('path');
 
-var apikey = process.argv[2];
-
 var _ = require('lodash');
 var Combinatorics = require('js-combinatorics');
-
-var combinations = {
-    level: ['debug', 'info', 'warn', 'error', 'fatal'],
-    period: ['1m', '1h', '1d', '1m', ''],
-    threshold: [0, 1, 10240, '100k', '1m', '1g'],
-    totalFiles: [0, 1, 2, 5, 10, 20],
-    totalSize: [0, '100k', '1m', '10m', '100m', '1g'],
-    rotateExisting: [true, false],
-    startNewFile: [true, false],
-    gzip: [true, false]
-};
 
 function validConfig(config) {
     var valid =


### PR DESCRIPTION
While I was working on #34, I noticed some imports that are unused. This PR removes them.

**Note:** Contribution guidelines say I need to `make check`, but that currently does this for me:

```console
❯ make check
make: *** No rule to make target `check'.  Stop.
```

But I believe I'm following the coding style.

I also think I ran the tests...?

```console
❯ npm test
npm ERR! Missing script: "test"
npm ERR! 
npm ERR! To see a list of scripts, run:
npm ERR!   npm run

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/kevin/.npm/_logs/2023-06-22T03_35_53_904Z-debug-0.log
❯ make test
make: `test' is up to date.
```

Definitely let me know if I need to do anything else here.