### PR TITLE
Move to Specific Lodash Imports (Fixes #34)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ Andrey Hohutkin <andrey.hohutkin@gmail.com>
 akk144 <akansh.agrawal@elanic.in>
 Connor Hindley <connor.hindley@tanium.com>
 Melvin Gutiérrez <melvin.gutierrez-rivero@gmail.com>
+Kevin Brown <kevin.brown@exogee.com>
 
 
 Based on and adapted from work by:

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var PeriodTrigger = require('./lib/periodtrigger');
 var InitialPeriodTrigger = require('./lib/initialperiodtrigger');
 var ThresholdTrigger = require('./lib/thresholdtrigger');
 var TriggerAdapter = require('./lib/triggeradapter');
-var _ = require('lodash');
+var extend = require('lodash/extend');
 
 var path = require('path');
 
@@ -14,7 +14,7 @@ var existingFilesStreams = {};
 
 function RotatingFileStreamFactory(options) {
     // options_in might be readonly, copy so that we can modify as needed
-    var options_copy = _.extend({}, options);
+    var options_copy = extend({}, options);
 
     if (typeof (options_copy.path) !== 'string') {
         throw new Error('Must provide a string for path');

--- a/lib/datestampedfileops.js
+++ b/lib/datestampedfileops.js
@@ -2,7 +2,9 @@ var fs = require('fs');
 var async = require('async');
 var path = require('path');
 var strftime = require('strftime');
-var _ = require('lodash');
+var filter = require('lodash/filter');
+var extend = require('lodash/extend');
+var some = require('lodash/some');
 
 var _DEBUG = false;
 
@@ -33,7 +35,7 @@ function DateStampedFileOps(logpath, totalFiles, totalSize, gzip) {
 
     function filterJustOurLogFiles(includeZipFiles) {
         return function (files, next) {
-            var logfiles = _.filter(files, function (file) {
+            var logfiles = filter(files, function (file) {
                 var parsedFile = path.parse(
                                     path.resolve(
                                         path.join(
@@ -67,7 +69,7 @@ function DateStampedFileOps(logpath, totalFiles, totalSize, gzip) {
                     parsedFile.name = splitname.slice(0, -1).join('.');
                 }
 
-                return (_.some(prefixes, function (prefix) { return parsedFile.name.indexOf(prefix) === 0; }) &&
+                return (some(prefixes, function (prefix) { return parsedFile.name.indexOf(prefix) === 0; }) &&
                         parsedFile.ext === parsedPath.ext);
             });
 
@@ -176,7 +178,7 @@ function DateStampedFileOps(logpath, totalFiles, totalSize, gzip) {
         if (reopenedFilePath !== null) {
             result = path.parse(reopenedFilePath);
         } else {
-            result = _.extend({}, parsedPath);
+            result = extend({}, parsedPath);
             if (nonce === 0) {
                 result.name = removeN(result.name);
             } else if (result.name.indexOf('%N') >= 0) {

--- a/lib/filerotator.js
+++ b/lib/filerotator.js
@@ -7,7 +7,7 @@
 
 var fs = require('fs');
 var async = require('async');
-var _ = require('lodash');
+var extend = require('lodash/extend');
 var zlib = require('zlib');
 var EventEmitter = require('events').EventEmitter;
 var NumberedFileOps = require('./numberedfileops');
@@ -141,7 +141,7 @@ function FileRotator(logpath, totalFiles, totalSize, gzip) {
         }
     }
 
-    return _.extend({}, {
+    return extend({}, {
         initialise: initialise,
         rotate: rotate,
         end: shutdownCurrentStream

--- a/lib/initialperiodtrigger.js
+++ b/lib/initialperiodtrigger.js
@@ -4,7 +4,7 @@
 
 var assert = require('assert');
 var EventEmitter = require('events').EventEmitter;
-var _ = require('lodash');
+var extend = require('lodash/extend');
 var fs = require('fs');
 
 var optionParser = require('./optionParser');
@@ -54,7 +54,7 @@ function InitialPeriodRotateTrigger(options) {
     periodScope = parsed.periodScope;
     periodNum = parsed.periodNum;
 
-    return _.extend({}, {
+    return extend({}, {
         newFile: newFile,
         logWrite: logWrite,
         shutdown: shutdown,

--- a/lib/limitedqueue.js
+++ b/lib/limitedqueue.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var async = require('async');
-var _ = require('lodash');
+var extend = require('lodash/extend');
 var EventEmitter = require('events').EventEmitter;
 
 function LimitedQueue(worker) {
@@ -26,14 +26,14 @@ function LimitedQueue(worker) {
             };
 
 
-            var inplace = _.extend(
+            var inplace = extend(
                 {},
                 {immediatelog: false},
                 notification
             );
             queue.push(JSON.stringify(inplace) + '\n');
 
-            var immediate = _.extend(
+            var immediate = extend(
                 {},
                 {immediatelog: true},
                 notification
@@ -60,14 +60,14 @@ function LimitedQueue(worker) {
                     'v':0
                 };
 
-                var inplace = _.extend(
+                var inplace = extend(
                     {},
                     {immediatelog: false},
                     notification
                 );
                 queue.push(JSON.stringify(inplace) + '\n');
 
-                var immediate = _.extend(
+                var immediate = extend(
                     {},
                     {immediatelog: true},
                     notification
@@ -96,7 +96,7 @@ function LimitedQueue(worker) {
                 'v':0
             };
 
-            var message = _.extend({}, {immediatelog: false}, notification);
+            var message = extend({}, {immediatelog: false}, notification);
             queue.push(JSON.stringify(message) + '\n');
 
             console.log(notification.message);
@@ -130,7 +130,7 @@ function LimitedQueue(worker) {
         }
     }
 
-    return _.extend({}, {
+    return extend({}, {
         push: push,
         paused: paused,
         pause: queue.pause,

--- a/lib/periodtrigger.js
+++ b/lib/periodtrigger.js
@@ -3,7 +3,7 @@
 'use strict';
 
 var EventEmitter = require('events').EventEmitter;
-var _ = require('lodash');
+var extend = require('lodash/extend');
 
 var optionParser = require('./optionParser');
 var nextRotTime = require('./nextrotationtime');
@@ -58,7 +58,7 @@ function PeriodRotateTrigger(options) {
 
     setupNextRotation();
 
-    return _.extend({}, {
+    return extend({}, {
         newFile: newFile,
         logWrite: logWrite,
         shutdown: shutdown

--- a/lib/rotatingfilestream.js
+++ b/lib/rotatingfilestream.js
@@ -5,7 +5,7 @@
 'use strict';
 
 var EventEmitter = require('events').EventEmitter;
-var _ = require('lodash');
+var extend = require('lodash/extend');
 
 var optionParser = require('./optionParser');
 var LimitedQueue = require('./limitedqueue');
@@ -248,7 +248,7 @@ function RotatingFileStream(options) {
         });
     }
 
-    return _.extend({}, {
+    return extend({}, {
         stream: stream,
         initialise: initialise,
         rotate: rotate,

--- a/lib/thresholdtrigger.js
+++ b/lib/thresholdtrigger.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var EventEmitter = require('events').EventEmitter;
-var _ = require('lodash');
+var extend = require('lodash/extend');
 var optionParser = require('./optionParser');
 
 function ThresholdTrigger(options) {
@@ -36,7 +36,7 @@ function ThresholdTrigger(options) {
 
     threshold = optionParser.parseSize(options.threshold);
 
-    return _.extend({}, {
+    return extend({}, {
         newFile: newFile,
         logWrite: logWrite,
         shutdown: shutdown

--- a/test.js
+++ b/test.js
@@ -1,10 +1,10 @@
 var bunyan = require('bunyan');
 var RotatingFileStream = require('./index');
-var _ = require('lodash');
+var extend = require('lodash/extend');
 
 options = { stream: { path: 'testlogs/bar-%y-%m-%d-%H-%M-%S-%N.log', totalFiles: 10, threshold: '1m', fieldOrder: ['pid', 'time'] } }
 
-var rfs = RotatingFileStream(_.extend({}, { path: 'foo.log' }, options.stream));
+var rfs = RotatingFileStream(extend({}, { path: 'foo.log' }, options.stream));
 
 var log = bunyan.createLogger({
     name: 'foo',

--- a/test/functionality.js
+++ b/test/functionality.js
@@ -1,5 +1,5 @@
 var bunyan = require('bunyan');
-var _ = require('lodash');
+var extend = require('lodash/extend');
 var fs = require('fs');
 var path = require('path');
 var readline = require('readline');
@@ -27,7 +27,7 @@ function fixpid(log) {
 }
 
 function runTest(name, options, next) {
-    var rfs = RotatingFileStream(_.extend({}, { path: 'foo.log', map: fixpid }, options.stream));
+    var rfs = RotatingFileStream(extend({}, { path: 'foo.log', map: fixpid }, options.stream));
 
     var log = bunyan.createLogger({
         name: 'foo',
@@ -52,7 +52,7 @@ function runTest(name, options, next) {
 
     var i = 1;
     var offset = (options.batch.startAt || 1) - 1;
-    var batch = _.extend({}, { size: 10 }, options.batch);
+    var batch = extend({}, { size: 10 }, options.batch);
 
     // Prior to node v4, high load scenarios (like these tests) can starve timer events
     var logdelay = batch.delay || (semver.lt(process.version, '4.0.0') ? 20 : 0);

--- a/test/performance.js
+++ b/test/performance.js
@@ -1,5 +1,5 @@
 var bunyan = require('bunyan');
-var _ = require('lodash');
+var extend = require('lodash/extend');
 var fs = require('fs');
 var assert = require('assert');
 var fse = require('fs-extra');
@@ -14,7 +14,7 @@ try {
 }
 
 function runTest(name, options, next) {
-    var rfs = RotatingFileStream(_.extend({}, { path: 'foo.log' }, options.stream));
+    var rfs = RotatingFileStream(extend({}, { path: 'foo.log' }, options.stream));
 
     var log = bunyan.createLogger({
         name: 'foo',
@@ -32,7 +32,7 @@ function runTest(name, options, next) {
     });
 
     var i = 0;
-    var batch = _.extend({}, { size: 8 }, options.batch);
+    var batch = extend({}, { size: 8 }, options.batch);
 
     var ia = setInterval(function () {
         for (var j = 0; j < batch.size; j += 1) {

--- a/test/stress.js
+++ b/test/stress.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 var async = require('async');
 var path = require('path');
 
-var _ = require('lodash');
+var extend = require('lodash/extend');
 var Combinatorics = require('js-combinatorics');
 
 function validConfig(config) {
@@ -112,7 +112,7 @@ function PerfMon() {
 
     }, 10000);
 
-    return _.extend({}, {
+    return extend({}, {
         addStream: addStream
     }, base);
 }


### PR DESCRIPTION
Moved to using individual `lodash` require statements to save on bundle size for package consumers using AWS Lambda or other bundle-friendly node destinations.

Fixes #34.