### PR TITLE
Fix missing var keyword in lib/datestampedfileops.js

### DIFF
--- a/lib/datestampedfileops.js
+++ b/lib/datestampedfileops.js
@@ -92,7 +92,7 @@ function DateStampedFileOps(logpath, totalFiles, totalSize, gzip) {
     }
 
     function filterUnstattedFiles(logstats, next) {
-        filteredlogstats = logstats.filter(logstat => logstat && logstat.stat && logstat.stat.mtime);
+        var filteredlogstats = logstats.filter(logstat => logstat && logstat.stat && logstat.stat.mtime);
         next(null, filteredlogstats);
     }
 


### PR DESCRIPTION
Resolves #42 by adding `var` keyword to the variable in question. 

Since this fixes a minor issue, I suggest a version bump to 2.0.6. I didn't include version bump in the PR as I was following the assumption that it's best to manage version and changelog from the main repo.

Suggested [CHANGES.md](CHANGES.md) entry:

```md
## 2.0.6

- (rgembalik) Fix - add missing `var` keyword in [lib/datestampedfileops.js](lib/datestampedfileops.js)
```